### PR TITLE
fix: use babelrc file by default

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -27,7 +27,7 @@ export default function macrosPlugin() {
 					],
 					require.resolve("babel-plugin-macros"),
 				],
-				babelrc: false,
+				babelrc: true,
 				configFile: false,
 				sourceMaps: true,
 			})


### PR DESCRIPTION
It will be interesting to enable existing babelrc file configuration, to support user configured features